### PR TITLE
Should publisher name also be a parameter?

### DIFF
--- a/Templates/resourceProjection.json
+++ b/Templates/resourceProjection.json
@@ -14,6 +14,12 @@
                 "description": "Name of the Managed Service Provider offering"
             }
         },
+        "publisherName": {
+            "type": "string",
+            "metadata": {
+                "description": "Specify the Azure Marketplace publisher name of the Managed Service Provider"
+            }
+        },
         "managedByTenantId": {
             "type": "string",
             "metadata": {
@@ -32,7 +38,7 @@
         "mspAssignmentName": "[guid(parameters('mspName'))]",
         "planName": "[parameters('mspName')]",
         "product": "[concat('marketplace-test','|', parameters('mspName'),'|',variables('version'), '|', 'preview','|',variables('version'))]",
-        "publisher": "Azure Marketplace",
+        "publisher": "[parameters('publisherName')]",
         "version": "1.0.0"
     },
     "resources": [

--- a/Templates/resourceProjection.parameters.json
+++ b/Templates/resourceProjection.parameters.json
@@ -11,6 +11,9 @@
         "managedByTenantId": {
             "value": "d6ad82f3-42af-4a15-ac1e-49e6c08f624e"
         },
+            "publisherName": {
+            "value": "Fabrikam"
+        },
         "authorizations": {
             "value": [
                 {


### PR DESCRIPTION
I'm assuming that each service provider would need to use their own publisher name.

If we make publisher name a parameter then I don't think there is a need for anyone to change the resourceprojection.json file.