### PR TITLE
Update template for setting up delegated resource management

### DIFF
--- a/Templates/resourceProjection.json
+++ b/Templates/resourceProjection.json
@@ -5,41 +5,55 @@
         "mspName": {
             "type": "string",
             "metadata": {
-                "description": "Specify the Managed Service Provider name"
+                "description": "Provide a name for this registration definition. For example the name of the Managed Service Provider's offer"
             }
         },
         "mspOfferDescription": {
             "type": "string",
             "metadata": {
-                "description": "Name of the Managed Service Provider offering"
-            }
-        },
-        "publisherName": {
-            "type": "string",
-            "metadata": {
-                "description": "Specify the Azure Marketplace publisher name of the Managed Service Provider"
+                "description": "Provide a description for this registration definition. For example contact or contract details."
             }
         },
         "managedByTenantId": {
             "type": "string",
             "metadata": {
-                "description": "Specify the tenant id of the Managed Service Provider"
+                "description": "Specify the Azure Active Directory tenant id of the Managed Service Provider. Resources will be shared to this tenant."
             }
         },
         "authorizations": {
             "type": "array",
             "metadata": {
-                "description": "Specify the MSP principalId's to rolDefinitionId's mapping in an array of objects"
+                "description": "Specify an array of objects, containing pairs of Azure Active Directory principalIds and corresponding Azure roleDefinitionId. The roleDefinition specified is granted to the principalId in the provider's Active Directory."
             }
-        }              
+        },
+        "marketplacePublisherId": {
+            "type": "string",
+            "metadata": {
+                "description": "Must match the Azure Marketplace Publisher ID for the marketplace offer."
+            }
+        },
+        "marketplaceOfferId": {
+            "type": "string",
+            "metadata": {
+                "description": "Must match the Azure Marketplace Offer ID for the marketplace offer."
+            }
+        },
+        "marketplacePlanId": {
+            "type": "string",
+            "metadata": {
+                "description": "Must match the Azure Marketplace Plan ID for the plan within the marketplace offer."
+            }
+        },
+        "marketplacePlanVersion": {
+            "type": "string",
+            "metadata": {
+                "description": "Must match the Azure Marketplace Plan version for the plan within the marketplace offer."
+            }
+        }
     },
     "variables": {
         "mspRegistrationName": "[guid(parameters('mspName'))]",
         "mspAssignmentName": "[guid(parameters('mspName'))]",
-        "planName": "[parameters('mspName')]",
-        "product": "[concat('marketplace-test','|', parameters('mspName'),'|',variables('version'), '|', 'preview','|',variables('version'))]",
-        "publisher": "[parameters('publisherName')]",
-        "version": "1.0.0"
     },
     "resources": [
         {
@@ -53,10 +67,10 @@
                 "authorizations": "[parameters('authorizations')]"
             },
             "plan": {
-                "name": "[variables('planName')]",
-                "product": "[variables('product')]",
-                "publisher": "[variables('publisher')]",
-                "version": "[variables('version')]"
+                "name": "[parameters('marketplacePlanId')]",
+                "product": "[parameters('marketplaceOfferId')]",
+                "publisher": "[parameters('marketplacePublisherId')]",
+                "version": "[parameters('marketplacePlanVersion')]"
             }
         },
         {

--- a/Templates/resourceProjection.json
+++ b/Templates/resourceProjection.json
@@ -105,6 +105,10 @@
         "authorizations": {
             "type": "array",
             "value": "[parameters('authorizations')]"
+        },
+        "marketplace": {
+            "type": "object",
+            "value": "[if(equals(parameters('marketplaceOffer'), 'Yes'), variables('marketplacePlan'), json('{\"offer\": \"No marketplace offer\"}'))]"
         }
     }
 }

--- a/Templates/resourceProjection.json
+++ b/Templates/resourceProjection.json
@@ -63,9 +63,7 @@
         }
     },
     "variables": {
-        "mspRegistrationName": "[if(equals(parameters('marketplaceOffer'), 'Yes'),guid(parameters('mspName'), 'Yes'), guid(parameters('mspName'), 'No'))]",
-        "mspRegistrationNameOfferYes": "[guid(parameters('mspName'), 'Yes')]",
-        "mspRegistrationNameOfferNo": "[guid(parameters('mspName'), 'No')]",
+        "mspRegistrationName": "[guid(parameters('mspName'))]",
         "mspAssignmentName": "[guid(parameters('mspName'))]",
         "marketplacePlan": {
             "name": "[parameters('marketplacePlanId')]",
@@ -76,29 +74,16 @@
     },
     "resources": [
         {
-            "condition": "[equals(parameters('marketplaceOffer'), 'Yes')]",
             "type": "Microsoft.ManagedServices/registrationDefinitions",
             "apiVersion": "2018-06-01-preview",
-            "name": "[variables('mspRegistrationNameOfferYes')]",
+            "name": "[variables('mspRegistrationName')]",
             "properties": {
                 "registrationDefinitionName": "[parameters('mspName')]",
                 "description": "[parameters('mspOfferDescription')]",
                 "managedByTenantId": "[parameters('managedByTenantId')]",
                 "authorizations": "[parameters('authorizations')]"
             },
-            "plan": "[variables('marketplacePlan')]"
-        },
-        {
-            "condition": "[equals(parameters('marketplaceOffer'), 'No')]",
-            "type": "Microsoft.ManagedServices/registrationDefinitions",
-            "apiVersion": "2018-06-01-preview",
-            "name": "[variables('mspRegistrationNameOfferNo')]",
-            "properties": {
-                "registrationDefinitionName": "[parameters('mspName')]",
-                "description": "[parameters('mspOfferDescription')]",
-                "managedByTenantId": "[parameters('managedByTenantId')]",
-                "authorizations": "[parameters('authorizations')]"
-            },
+            "plan": "[if(equals(parameters('marketplaceOffer'), 'Yes'), variables('marketplacePlan'), json('null'))]"
         },
         {
             "type": "Microsoft.ManagedServices/registrationAssignments",

--- a/Templates/resourceProjection.json
+++ b/Templates/resourceProjection.json
@@ -26,52 +26,79 @@
                 "description": "Specify an array of objects, containing pairs of Azure Active Directory principalIds and corresponding Azure roleDefinitionId. The roleDefinition specified is granted to the principalId in the provider's Active Directory."
             }
         },
+        "marketplaceOffer": {
+            "type": "string",
+            "defaultValue": "Yes",
+            "metadata": {
+                "description": "Does this deployment include plan details that match an offer published in the Azure Marketplace?"
+            }
+        },
         "marketplacePublisherId": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "Must match the Azure Marketplace Publisher ID for the marketplace offer."
             }
         },
         "marketplaceOfferId": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "Must match the Azure Marketplace Offer ID for the marketplace offer."
             }
         },
         "marketplacePlanId": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "Must match the Azure Marketplace Plan ID for the plan within the marketplace offer."
             }
         },
         "marketplacePlanVersion": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "Must match the Azure Marketplace Plan version for the plan within the marketplace offer."
             }
         }
     },
     "variables": {
-        "mspRegistrationName": "[guid(parameters('mspName'))]",
+        "mspRegistrationName": "[if(equals(parameters('marketplaceOffer'), 'Yes'),guid(parameters('mspName'), 'Yes'), guid(parameters('mspName'), 'No'))]",
+        "mspRegistrationNameOfferYes": "[guid(parameters('mspName'), 'Yes')]",
+        "mspRegistrationNameOfferNo": "[guid(parameters('mspName'), 'No')]",
         "mspAssignmentName": "[guid(parameters('mspName'))]",
+        "marketplacePlan": {
+            "name": "[parameters('marketplacePlanId')]",
+            "product": "[parameters('marketplaceOfferId')]",
+            "publisher": "[parameters('marketplacePublisherId')]",
+            "version": "[parameters('marketplacePlanVersion')]"
+        }        
     },
     "resources": [
         {
+            "condition": "[equals(parameters('marketplaceOffer'), 'Yes')]",
             "type": "Microsoft.ManagedServices/registrationDefinitions",
             "apiVersion": "2018-06-01-preview",
-            "name": "[variables('mspRegistrationName')]",
+            "name": "[variables('mspRegistrationNameOfferYes')]",
             "properties": {
                 "registrationDefinitionName": "[parameters('mspName')]",
                 "description": "[parameters('mspOfferDescription')]",
                 "managedByTenantId": "[parameters('managedByTenantId')]",
                 "authorizations": "[parameters('authorizations')]"
             },
-            "plan": {
-                "name": "[parameters('marketplacePlanId')]",
-                "product": "[parameters('marketplaceOfferId')]",
-                "publisher": "[parameters('marketplacePublisherId')]",
-                "version": "[parameters('marketplacePlanVersion')]"
-            }
+            "plan": "[variables('marketplacePlan')]"
+        },
+        {
+            "condition": "[equals(parameters('marketplaceOffer'), 'No')]",
+            "type": "Microsoft.ManagedServices/registrationDefinitions",
+            "apiVersion": "2018-06-01-preview",
+            "name": "[variables('mspRegistrationNameOfferNo')]",
+            "properties": {
+                "registrationDefinitionName": "[parameters('mspName')]",
+                "description": "[parameters('mspOfferDescription')]",
+                "managedByTenantId": "[parameters('managedByTenantId')]",
+                "authorizations": "[parameters('authorizations')]"
+            },
         },
         {
             "type": "Microsoft.ManagedServices/registrationAssignments",

--- a/Templates/resourceProjection.parameters.json
+++ b/Templates/resourceProjection.parameters.json
@@ -6,7 +6,7 @@
             "value": "Fabrikam Managed Services - Assessment"
         },
         "mspOfferDescription": {
-            "value": "Template for demonstration purposes. Edit to contain your values. Values for marketplace parameters are available from the Cloud Partner Portal."
+            "value": "Template for demonstration purposes. Edit to contain your values. If marketplaceOffer = Yes, then values for marketplace parameters must match the offer details in the Cloud Partner Portal."
         },
         "managedByTenantId": {
             "value": "d6ad82f3-42af-4a15-ac1e-49e6c08f624e"
@@ -26,6 +26,9 @@
                     "roleDefinitionId": "36243c78-bf99-498c-9df9-86d9f8d28608"
                 }
             ]
+        },
+            "marketplaceOffer": {
+            "value": "No"
         },
             "marketplacePublisherId": {
             "value": "marketplace-test"

--- a/Templates/resourceProjection.parameters.json
+++ b/Templates/resourceProjection.parameters.json
@@ -3,16 +3,13 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "mspName": {
-            "value": "Fabrikam Managed Services - Interstellar"
+            "value": "Fabrikam Managed Services - Assessment"
         },
         "mspOfferDescription": {
-            "value": "Fabrikam Managed Services - Interstellar"
+            "value": "Template for demonstration purposes. Edit to contain your values. Values for marketplace parameters are available from the Cloud Partner Portal."
         },
         "managedByTenantId": {
             "value": "d6ad82f3-42af-4a15-ac1e-49e6c08f624e"
-        },
-            "publisherName": {
-            "value": "Fabrikam"
         },
         "authorizations": {
             "value": [
@@ -29,6 +26,18 @@
                     "roleDefinitionId": "36243c78-bf99-498c-9df9-86d9f8d28608"
                 }
             ]
-        }
+        },
+            "marketplacePublisherId": {
+            "value": "marketplace-test"
+        },
+            "marketplaceOfferId": {
+            "value": "fabrikam-assessment"
+        },
+            "marketplacePlanId": {
+            "value": "assessment"
+        },
+            "marketplacePlanVersion": {
+            "value": "2.0.0"
+        }        
     }
 }


### PR DESCRIPTION
To support PAL, and offers that are based on a % of spend, the plan object needs to match the values set when creating the offer in the Cloud Partner Portal. These updates change the template and parameter files so that plan details are set correctly.